### PR TITLE
Don't Use "ip:" prefix for USB mode

### DIFF
--- a/src/aditof_utils.cpp
+++ b/src/aditof_utils.cpp
@@ -82,7 +82,9 @@ std::string * parseArgs(int argc, char ** argv)
   }
 
   std::string * result = new std::string[5];
-  result[0] = std::string("ip:") + ip;
+  if (!ip.empty()) {
+    result[0] = std::string("ip:") + ip;
+  }
   result[1] = config_path;
   result[2] = mode;
 


### PR DESCRIPTION
I tried to run the ros2 bindings on NXP Eval-kit and found following issue when ip wasn't provided in the argument:

```
/opt/ros/galactic/bin/ros2:6: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  from pkg_resources import load_entry_point
I20231016 11:16:15.326846 3321778 aditof_utils.cpp:74] No ip provided, attempting to connect to the camera through USB
I20231016 11:16:15.327349 3321778 aditof_utils.cpp:95] Started camera intialization
I20231016 11:16:15.327402 3321778 system_impl.cpp:92] SDK built with websockets version:3.1.0
I20231016 11:16:15.327478 3321778 network_sensor_enumerator.cpp:57] Looking for sensors over network:
[2023/10/16 11:16:15:3282] NOTICE: Creating Vhost 'default' (serving disabled), 1 protocols, IPv6 off
[2023/10/16 11:16:15:3294] ERR: getaddrinfo failed: -2
Connection Error
terminate called after throwing an instance of 'std::out_of_range'
  what():  vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)
```

Since we are running on the Native host, ip is not required. The [parsed ip is blank] (https://github.com/meetgandhi-eic/tof-ros2/blob/main/src/aditof_utils.cpp#L73) but later on the ["ip:" prefix is added](https://github.com/meetgandhi-eic/tof-ros2/blob/main/src/aditof_utils.cpp#L85).
This fails the camera initialisation as tries to init the camera with the [blank IP] (https://github.com/meetgandhi-eic/tof-ros2/blob/main/src/aditof_utils.cpp#L103)

Fix:
- Add "ip:" prefix only if valid ip is provided.

Logs after the fix is applied:

```
/opt/ros/galactic/bin/ros2:6: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  from pkg_resources import load_entry_point
I20231016 11:23:28.830083 3323687 aditof_utils.cpp:74] No ip provided, attempting to connect to the camera through USB
I20231016 11:23:28.830291 3323687 aditof_utils.cpp:97] Started camera intialization
I20231016 11:23:28.830315 3323687 system_impl.cpp:92] SDK built with websockets version:3.1.0
I20231016 11:23:28.830358 3323687 usb_sensor_enumerator.cpp:61] Looking for USB connected sensors
```